### PR TITLE
Update wdl to gatk4.0.8.0 release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ To invoke Oncotator on the called tumor copy-ratio segments:
 Further explanation of these task-level parameters may be found by invoking the ``--help`` documentation available in the gatk.jar for each tool.
 
 ##Important 
-The data in gs://gatk-test-data/1kgp are from the 1000 Genomes Project (http://www.internationalgenome.org/home) and are provided as is. 
-If you have questions on the data, please direct them to the 1000 Genomes Project email at info@1000genomes.org.
-Do NOT post questions about the data to the GATK forum.
+- The data in gs://gatk-test-data/1kgp are from the 1000 Genomes Project (http://www.internationalgenome.org/home) and are provided as is. 
+  If you have questions on the data, please direct them to the 1000 Genomes Project email at info@1000genomes.org. Do NOT post questions about the data to the GATK forum.
+- Runtime parameters are optimized for Broad's Google Cloud Platform implementation.
+- For help running workflows on the Google Cloud Platform or locally please view the following tutorial [(How to) Execute Workflows from the gatk-workflows Git Organization](https://software.broadinstitute.org/gatk/documentation/article?id=12521).

--- a/cnv_common_tasks.wdl
+++ b/cnv_common_tasks.wdl
@@ -1,5 +1,6 @@
 task PreprocessIntervals {
     File? intervals
+    File? blacklist_intervals
     File ref_fasta
     File ref_fasta_fai
     File ref_fasta_dict
@@ -28,6 +29,7 @@ task PreprocessIntervals {
 
         gatk --java-options "-Xmx${command_mem_mb}m" PreprocessIntervals \
             ${"-L " + intervals} \
+            ${"-XL " + blacklist_intervals} \
             --sequence-dictionary ${ref_fasta_dict} \
             --reference ${ref_fasta} \
             --padding ${default="250" padding} \

--- a/cnv_somatic_pair_workflow.b37.inputs.json
+++ b/cnv_somatic_pair_workflow.b37.inputs.json
@@ -14,7 +14,7 @@
   "CNVSomaticPairWorkflow.intervals": "gs://gatk-test-data/cnv/somatic/ice_targets.tsv.interval_list",
 
   "##_COMMENT3": "Docker",
-  "CNVSomaticPairWorkflow.gatk_docker": "broadinstitute/gatk:4.0.4.0",
+  "CNVSomaticPairWorkflow.gatk_docker": "broadinstitute/gatk:4.0.8.0",
   "##CNVSomaticPairWorkflow.oncotator_docker": "(optional) String?",
 
   "##_COMMENT4": "Memory Optional",

--- a/cnv_somatic_pair_workflow.wdl
+++ b/cnv_somatic_pair_workflow.wdl
@@ -2,12 +2,19 @@
 #
 # Notes:
 #
-# - The interval-list file is required for both WGS and WES workflows and should be a Picard or GATK-style interval list.
+# - The intervals argument is required for both WGS and WES workflows and accepts formats compatible with the
+#   GATK -L argument (see https://gatkforums.broadinstitute.org/gatk/discussion/11009/intervals-and-interval-lists).
 #   These intervals will be padded on both sides by the amount specified by PreprocessIntervals.padding (default 250)
 #   and split into bins of length specified by PreprocessIntervals.bin_length (default 1000; specify 0 to skip binning,
-#   e.g. for WES).  For WGS, the intervals should simply cover the autosomal chromosomes (sex chromosomes may be
+#   e.g., for WES).  For WGS, the intervals should simply cover the autosomal chromosomes (sex chromosomes may be
 #   included, but care should be taken to 1) avoid creating panels of mixed sex, and 2) denoise case samples only
 #   with panels containing only individuals of the same sex as the case samples).
+#
+# - Intervals can be blacklisted from coverage collection and all downstream steps by using the blacklist_intervals
+#   argument, which accepts formats compatible with the GATK -XL argument
+#   (see https://gatkforums.broadinstitute.org/gatk/discussion/11009/intervals-and-interval-lists).
+#   This may be useful for excluding centromeric regions, etc. from analysis.  Alternatively, these regions may
+#   be manually filtered from the final callset.
 #
 # - The sites file (common_sites) should be a Picard or GATK-style interval list.  This is a list of sites
 #   of known variation at which allelic counts will be collected for use in modeling minor-allele fractions.
@@ -28,6 +35,7 @@ workflow CNVSomaticPairWorkflow {
     ##################################
     File common_sites
     File intervals
+    File? blacklist_intervals
     File tumor_bam
     File tumor_bam_idx
     File? normal_bam
@@ -126,7 +134,7 @@ workflow CNVSomaticPairWorkflow {
 
     Int gatk4_override_size = if defined(gatk4_jar_override) then ceil(size(gatk4_jar_override, "GB")) else 0
     # This is added to every task as padding, should increase if systematically you need more disk for every call
-    Int disk_pad = 20 + ceil(size(intervals, "GB")) + ceil(size(common_sites, "GB")) + gatk4_override_size + select_first([emergency_extra_disk,0])
+    Int disk_pad = 20 + ceil(size(intervals, "GB")) + ceil(size(common_sites, "GB")) + gatk4_override_size + select_first([emergency_extra_disk, 0])
 
     File final_normal_bam = select_first([normal_bam, "null"])
     File final_normal_bam_idx = select_first([normal_bam_idx, "null"])
@@ -135,6 +143,7 @@ workflow CNVSomaticPairWorkflow {
     call CNVTasks.PreprocessIntervals {
         input:
             intervals = intervals,
+            blacklist_intervals = blacklist_intervals,
             ref_fasta = ref_fasta,
             ref_fasta_fai = ref_fasta_fai,
             ref_fasta_dict = ref_fasta_dict,
@@ -428,6 +437,8 @@ workflow CNVSomaticPairWorkflow {
         File het_allelic_counts_tumor = ModelSegmentsTumor.het_allelic_counts
         File normal_het_allelic_counts_tumor = ModelSegmentsTumor.normal_het_allelic_counts
         File copy_ratio_only_segments_tumor = ModelSegmentsTumor.copy_ratio_only_segments
+        File copy_ratio_legacy_segments_tumor = ModelSegmentsTumor.copy_ratio_legacy_segments
+        File allele_fraction_legacy_segments_tumor = ModelSegmentsTumor.allele_fraction_legacy_segments
         File modeled_segments_begin_tumor = ModelSegmentsTumor.modeled_segments_begin
         File copy_ratio_parameters_begin_tumor = ModelSegmentsTumor.copy_ratio_parameters_begin
         File allele_fraction_parameters_begin_tumor = ModelSegmentsTumor.allele_fraction_parameters_begin
@@ -452,6 +463,8 @@ workflow CNVSomaticPairWorkflow {
         File? het_allelic_counts_normal = ModelSegmentsNormal.het_allelic_counts
         File? normal_het_allelic_counts_normal = ModelSegmentsNormal.normal_het_allelic_counts
         File? copy_ratio_only_segments_normal = ModelSegmentsNormal.copy_ratio_only_segments
+        File? copy_ratio_legacy_segments_normal = ModelSegmentsNormal.copy_ratio_legacy_segments
+        File? allele_fraction_legacy_segments_normal = ModelSegmentsNormal.allele_fraction_legacy_segments
         File? modeled_segments_begin_normal = ModelSegmentsNormal.modeled_segments_begin
         File? copy_ratio_parameters_begin_normal = ModelSegmentsNormal.copy_ratio_parameters_begin
         File? allele_fraction_parameters_begin_normal = ModelSegmentsNormal.allele_fraction_parameters_begin
@@ -606,6 +619,8 @@ task ModelSegments {
         File het_allelic_counts = "${output_dir_}/${entity_id}.hets.tsv"
         File normal_het_allelic_counts = "${output_dir_}/${entity_id}.hets.normal.tsv"
         File copy_ratio_only_segments = "${output_dir_}/${entity_id}.cr.seg"
+        File copy_ratio_legacy_segments = "${output_dir_}/${entity_id}.cr.igv.seg"
+        File allele_fraction_legacy_segments = "${output_dir_}/${entity_id}.af.igv.seg"
         File modeled_segments_begin = "${output_dir_}/${entity_id}.modelBegin.seg"
         File copy_ratio_parameters_begin = "${output_dir_}/${entity_id}.modelBegin.cr.param"
         File allele_fraction_parameters_begin = "${output_dir_}/${entity_id}.modelBegin.af.param"
@@ -767,4 +782,3 @@ task PlotModeledSegments {
         File modeled_segments_plot = "${output_dir_}/${entity_id}.modeled.png"
     }
 }
-

--- a/cnv_somatic_panel_workflow.b37.inputs.json
+++ b/cnv_somatic_panel_workflow.b37.inputs.json
@@ -11,7 +11,7 @@
   "CNVSomaticPanelWorkflow.intervals": "gs://gatk-test-data/cnv/somatic/ice_targets.tsv.interval_list",
 
   "##_COMMENT3": "Docker",
-  "CNVSomaticPanelWorkflow.gatk_docker": "broadinstitute/gatk:4.0.4.0",
+  "CNVSomaticPanelWorkflow.gatk_docker": "broadinstitute/gatk:4.0.8.0",
 
   "##_COMMENT4": "Disk Size Optional",
   "##CNVSomaticPanelWorkflow.AnnotateIntervals.disk_space_gb": "(optional) Int?",

--- a/cnv_somatic_panel_workflow.wdl
+++ b/cnv_somatic_panel_workflow.wdl
@@ -2,12 +2,19 @@
 #
 # Notes:
 #
-# - The interval-list file is required for both WGS and WES workflows and should be a Picard or GATK-style interval list.
+# - The intervals argument is required for both WGS and WES workflows and accepts formats compatible with the
+#   GATK -L argument (see https://gatkforums.broadinstitute.org/gatk/discussion/11009/intervals-and-interval-lists).
 #   These intervals will be padded on both sides by the amount specified by PreprocessIntervals.padding (default 250)
 #   and split into bins of length specified by PreprocessIntervals.bin_length (default 1000; specify 0 to skip binning,
-#   e.g. for WES).  For WGS, the intervals should simply cover the autosomal chromosomes (sex chromosomes may be
+#   e.g., for WES).  For WGS, the intervals should simply cover the autosomal chromosomes (sex chromosomes may be
 #   included, but care should be taken to 1) avoid creating panels of mixed sex, and 2) denoise case samples only
 #   with panels containing only individuals of the same sex as the case samples).
+#
+# - Intervals can be blacklisted from coverage collection and all downstream steps by using the blacklist_intervals
+#   argument, which accepts formats compatible with the GATK -XL argument
+#   (see https://gatkforums.broadinstitute.org/gatk/discussion/11009/intervals-and-interval-lists).
+#   This may be useful for excluding centromeric regions, etc. from analysis.  Alternatively, these regions may
+#   be manually filtered from the final callset.
 #
 # - Example invocation:
 #
@@ -23,6 +30,7 @@ workflow CNVSomaticPanelWorkflow {
     #### required basic arguments ####
     ##################################
     File intervals
+    File? blacklist_intervals
     Array[String] normal_bams
     Array[String] normal_bais
     String pon_entity_id
@@ -76,6 +84,7 @@ workflow CNVSomaticPanelWorkflow {
     call CNVTasks.PreprocessIntervals {
         input:
             intervals = intervals,
+            blacklist_intervals = blacklist_intervals,
             ref_fasta = ref_fasta,
             ref_fasta_fai = ref_fasta_fai,
             ref_fasta_dict = ref_fasta_dict,
@@ -200,4 +209,3 @@ task CreateReadCountPanelOfNormals {
         File read_count_pon = "${pon_entity_id}.pon.hdf5"
     }
 }
-


### PR DESCRIPTION
gatk4.0.7.0 release notes:
- Exposed ability to blacklist intervals in CNV WDLs. 
- Added output of IGV-compatible .seg files to ModelSegments. 