### PR TITLE
Fix evaluate "NA" as a float

### DIFF
--- a/cnv_somatic_pair_workflow.wdl
+++ b/cnv_somatic_pair_workflow.wdl
@@ -813,7 +813,8 @@ task PlotDenoisedCopyRatios {
         File delta_MAD = "${output_dir_}/${entity_id}.deltaMAD.txt"
         Float delta_MAD_value = read_float(delta_MAD)
         File scaled_delta_MAD = "${output_dir_}/${entity_id}.scaledDeltaMAD.txt"
-        Float scaled_delta_MAD_value = read_float(scaled_delta_MAD)
+        String scaled_delta_MAD_str = read_string(scaled_delta_MAD)
+        Float scaled_delta_MAD_value = if scaled_delta_MAD_str == "NA" then 0 else read_float(scaled_delta_MAD)
     }
 }
 


### PR DESCRIPTION
When you have only 2 samples and use the normal one for panel, the "scaledDeltaMAD.txt" for normal will be "NA", which is not a number.

```
[error] WorkflowManagerActor Workflow 0154328b-fb76-4c18-a94f-c502e0cb9095 failed (during ExecutingWorkflowState): cromwell.backend.standard.StandardAsyncExecutionActor$$anon$2: Failed to evaluate job outputs:
Bad output 'PlotDenoisedCopyRatiosNormal.scaled_delta_MAD_value': For input string: "NA"
	at cromwell.backend.standard.StandardAsyncExecutionActor.$anonfun$handleExecutionSuccess$1(StandardAsyncExecutionActor.scala:876)
```
